### PR TITLE
CI test add windows environment run and close open file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,19 +10,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
         - uses: actions/checkout@v4
+        # Go module cache
+        - name: Cache Go modules
+          uses: actions/cache@v2
+          with:
+            path: |
+              ~/go/pkg/mod
+              ~/go/bin/*
+            key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-go-
         # goのセットアップ
         - name: Set up golang
           uses: actions/setup-go@v4
           with:
             go-version: '>=1.20'
-        # キャッシュの設定
-        - name: Cache staticcheck
-          uses: actions/cache@v2
-          with:
-            path: ~/go/bin/staticcheck
-            key: ${{ runner.os }}-staticcheck-${{ hashFiles('**/go.sum') }}
-            restore-keys: |
-              ${{ runner.os }}-staticcheck-
         # staticcheckインストール
         - name: Install staticcheck
           run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,7 @@ jobs:
             then
               go install honnef.co/go/tools/cmd/staticcheck@latest
             fi
+          shell: bash # Windows環境考慮
         # build
         - name: Build
           run: go build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,10 @@ on: [push]
 
 jobs:
   test-and-lint:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
         - uses: actions/checkout@v4
         # goのセットアップ

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
         - uses: actions/checkout@v4
+        # goのセットアップ
+        - name: Set up golang
+          uses: actions/setup-go@v4
+          with:
+            go-version: '>=1.20'
         # Go module cache
         - name: Cache Go modules
           uses: actions/cache@v2
@@ -20,11 +25,6 @@ jobs:
             key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
             restore-keys: |
               ${{ runner.os }}-go-
-        # goのセットアップ
-        - name: Set up golang
-          uses: actions/setup-go@v4
-          with:
-            go-version: '>=1.20'
         # staticcheckインストール
         - name: Install staticcheck
           run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,21 @@ jobs:
           uses: actions/setup-go@v4
           with:
             go-version: '>=1.20'
+        # キャッシュの設定
+        - name: Cache staticcheck
+          uses: actions/cache@v2
+          with:
+            path: ~/go/bin/staticcheck
+            key: ${{ runner.os }}-staticcheck-${{ hashFiles('**/go.sum') }}
+            restore-keys: |
+              ${{ runner.os }}-staticcheck-
         # staticcheckインストール
         - name: Install staticcheck
-          run: go install honnef.co/go/tools/cmd/staticcheck@latest
+          run: |
+            if ! command -v staticcheck &> /dev/null
+            then
+              go install honnef.co/go/tools/cmd/staticcheck@latest
+            fi
         # build
         - name: Build
           run: go build

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,6 +1,7 @@
 package file_test
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +11,12 @@ import (
 
 func TestExist(t *testing.T) {
 	tmpdir := t.TempDir()
+
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpdir); err != nil {
+			log.Fatal(err)
+		}
+	})
 
 	if err := os.Mkdir(filepath.Join(tmpdir, "dir"), 0777); err != nil {
 		t.Fatal(err)

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -2,32 +2,19 @@ package file_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/JY8752/note-cli/internal/file"
 )
 
-func removeDir(dir string) {
-	for i := 0; i < 10; i++ {
-		if err := os.RemoveAll(dir); err == nil {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-}
-
 func TestExist(t *testing.T) {
 	tmpdir := t.TempDir()
 
-	t.Cleanup(func() {
-		removeDir(tmpdir)
-	})
-
-	if err := os.Mkdir(tmpdir+"/dir", 0777); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpdir, "dir"), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.OpenFile(tmpdir+"/dir/test.txt", os.O_CREATE, 0777); err != nil {
+	if _, err := os.OpenFile(filepath.Join(tmpdir+"dir"+"test.txt"), os.O_CREATE, 0777); err != nil {
 		t.Fatal(err)
 	}
 
@@ -38,22 +25,22 @@ func TestExist(t *testing.T) {
 	}{
 		{
 			"file is exist",
-			tmpdir + "/dir/test.txt",
+			filepath.Join(tmpdir, "dir", "test.txt"),
 			true,
 		},
 		{
 			"file is not exist",
-			tmpdir + "/dir/test2.txt",
+			filepath.Join(tmpdir, "dir", "test2.txt"),
 			false,
 		},
 		{
 			"directory is exist",
-			tmpdir + "/dir",
+			filepath.Join(tmpdir, "dir"),
 			true,
 		},
 		{
 			"directory is not exist",
-			tmpdir + "/dir2",
+			filepath.Join(tmpdir, "dir2"),
 			false,
 		},
 	}

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,6 +1,7 @@
 package file_test
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -9,6 +10,12 @@ import (
 
 func TestExist(t *testing.T) {
 	tmpdir := t.TempDir()
+
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpdir); err != nil {
+			log.Fatal(err)
+		}
+	})
 
 	if err := os.Mkdir(tmpdir+"/dir", 0777); err != nil {
 		t.Fatal(err)

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,7 +1,6 @@
 package file_test
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,18 +11,20 @@ import (
 func TestExist(t *testing.T) {
 	tmpdir := t.TempDir()
 
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpdir); err != nil {
-			log.Fatal(err)
-		}
-	})
-
 	if err := os.Mkdir(filepath.Join(tmpdir, "dir"), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.OpenFile(filepath.Join(tmpdir, "dir", "test.txt"), os.O_CREATE, 0777); err != nil {
+
+	f, err := os.OpenFile(filepath.Join(tmpdir, "dir", "test.txt"), os.O_CREATE, 0777)
+	if err != nil {
 		t.Fatal(err)
 	}
+
+	t.Cleanup(func() {
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	testcases := []struct {
 		name string

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -14,7 +14,7 @@ func TestExist(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(tmpdir, "dir"), 0777); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.OpenFile(filepath.Join(tmpdir+"dir"+"test.txt"), os.O_CREATE, 0777); err != nil {
+	if _, err := os.OpenFile(filepath.Join(tmpdir, "dir", "test.txt"), os.O_CREATE, 0777); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,20 +1,27 @@
 package file_test
 
 import (
-	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/JY8752/note-cli/internal/file"
 )
+
+func removeDir(dir string) {
+	for i := 0; i < 10; i++ {
+		if err := os.RemoveAll(dir); err == nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
 
 func TestExist(t *testing.T) {
 	tmpdir := t.TempDir()
 
 	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpdir); err != nil {
-			log.Fatal(err)
-		}
+		removeDir(tmpdir)
 	})
 
 	if err := os.Mkdir(tmpdir+"/dir", 0777); err != nil {

--- a/internal/run/create.go
+++ b/internal/run/create.go
@@ -30,7 +30,7 @@ type Options struct {
 type Option func(*Options)
 
 func CreateArticleFunc(timeFlag *bool, name *string, options ...Option) RunEFunc {
-	return func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) (err error) {
 		t := *timeFlag
 		n := *name
 
@@ -73,7 +73,7 @@ func CreateArticleFunc(timeFlag *bool, name *string, options ...Option) RunEFunc
 
 		// mkdir
 		targetDir := filepath.Join(op.BasePath, dirName)
-		if err := os.Mkdir(targetDir, 0744); err != nil {
+		if err = os.Mkdir(targetDir, 0744); err != nil {
 			return err
 		}
 
@@ -81,7 +81,13 @@ func CreateArticleFunc(timeFlag *bool, name *string, options ...Option) RunEFunc
 
 		// create markdown file
 		filePath := filepath.Join(targetDir, fmt.Sprintf("%s.md", dirName))
-		if _, err := os.OpenFile(filePath, os.O_CREATE, 0644); err != nil {
+		f, err := os.OpenFile(filePath, os.O_CREATE, 0644)
+		defer func() {
+			if err = f.Close(); err != nil {
+				fmt.Printf("failed close file. file: %s\n", filePath)
+			}
+		}()
+		if err != nil {
 			return err
 		}
 
@@ -89,7 +95,7 @@ func CreateArticleFunc(timeFlag *bool, name *string, options ...Option) RunEFunc
 
 		// create config.yaml
 		configFilePath := filepath.Join(targetDir, ConfigFile)
-		if err := os.WriteFile(configFilePath, []byte("title: article title\nauthor: your name"), 0644); err != nil {
+		if err = os.WriteFile(configFilePath, []byte("title: article title\nauthor: your name"), 0644); err != nil {
 			return err
 		}
 

--- a/internal/run/create_test.go
+++ b/internal/run/create_test.go
@@ -1,6 +1,7 @@
 package run_test
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,6 +18,12 @@ func TestCreateArticleFunc(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
+
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			log.Fatal(err)
+		}
+	})
 
 	testcases := []struct {
 		name                   string

--- a/internal/run/create_test.go
+++ b/internal/run/create_test.go
@@ -1,7 +1,6 @@
 package run_test
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -18,12 +17,6 @@ func TestCreateArticleFunc(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-
-	t.Cleanup(func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			log.Fatal(err)
-		}
-	})
 
 	testcases := []struct {
 		name                   string


### PR DESCRIPTION
#8 

- Running test CI on Windows and Mac.
- Use cache modules for Running CI.
- ```os.OpenFile``` return ```*os.File```, but blank ```_```. In the Windows environment, an error occurs when trying to delete **a file that is still open**.So, close opened file.

```go
if _, err := os.OpenFile(tmpdir+"/dir/test.txt", os.O_CREATE, 0777); err != nil {
```